### PR TITLE
Remove a page argument check.

### DIFF
--- a/lib/insite/page/defined_page.rb
+++ b/lib/insite/page/defined_page.rb
@@ -264,15 +264,6 @@ module Insite
 
       match = @url_template.match(@browser.url)
 
-      # Raise if args are provided and the page doesn't take any args.
-      if (@all_arguments - [:scheme]).empty? && args
-        raise(
-          Insite::Errors::PageInitError,
-          "#{args.class} was provided as a #{self.class.name} initialization argument, " \
-          "but the page URL doesn't require any arguments.\n\n#{caller.join("\n")}"
-        )
-      end
-
       if @all_arguments.present? && !args
         @all_arguments.each do |arg|
           if match && match.keys.include?(arg.to_s)

--- a/lib/insite/version.rb
+++ b/lib/insite/version.rb
@@ -1,3 +1,3 @@
 module Insite
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/site_spec.rb
+++ b/spec/site_spec.rb
@@ -140,11 +140,6 @@ describe "page objects" do
     lang = Lang.new('en')
     @site.home_page lang
   end
-
-  it "raises when the page URL has no arguments but page arguments are provided" do
-    expect { @site.no_attr_page foo: 'bar' }.to raise_error Insite::Errors::PageInitError
-  end
-
 end
 
 describe "Site Object Delegation" do


### PR DESCRIPTION
No one likes a complainer. Don't raise an error when args are provided but page takes no args.